### PR TITLE
fix :: 프로필 화면 넘침 오류 해결 #30

### DIFF
--- a/src/components/common/Layout/index.tsx
+++ b/src/components/common/Layout/index.tsx
@@ -7,10 +7,10 @@ interface Props {
 
 const Layout = ({ children }: Props) => {
   return (
-    <>
+    <S.ContainerWrap>
       <Nav />
       <S.Container>{children}</S.Container>
-    </>
+    </S.ContainerWrap>
   );
 };
 

--- a/src/components/common/Layout/style.ts
+++ b/src/components/common/Layout/style.ts
@@ -1,5 +1,11 @@
 import styled from "styled-components";
 
+export const ContainerWrap = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+`;
+
 export const Container = styled.div`
   margin-left: 250px;
 `;

--- a/src/components/common/RankingList/style.ts
+++ b/src/components/common/RankingList/style.ts
@@ -1,9 +1,9 @@
 import styled from "styled-components";
 
 export const ListContainer = styled.div`
+  min-width: 750px;
   display: flex;
   flex-direction: column;
-  
 `;
 
 export const TableContainer = styled.div`


### PR DESCRIPTION
📚 한 일
- 화면 축소 시 화면 밖으로 프로필 넘어가는 오류 고쳤습니다.

https://github.com/user-attachments/assets/9604a279-cc0e-4e96-a7e3-8c29731409d7




